### PR TITLE
!fix: Change the parameter order to align with other packages with similar api

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -67,12 +67,12 @@ func (e *Encoder) statusCode(statusCode int, err error) error {
 }
 
 // StatusCodeWithMessage writes a statusCode and message to the response header and returns the original error
-func (e *Encoder) StatusCodeWithMessage(statusCode int, message string, err error) error {
-	return e.statusCodeWithMessage(statusCode, message, err)
+func (e *Encoder) StatusCodeWithMessage(statusCode int, err error, message string) error {
+	return e.statusCodeWithMessage(statusCode, err, message)
 }
 
 // statusCodeWithMessage writes a statusCode and message to the response header and returns the original error
-func (e *Encoder) statusCodeWithMessage(statusCode int, message string, err error) error {
+func (e *Encoder) statusCodeWithMessage(statusCode int, err error, message string) error {
 	e.w.WriteHeader(statusCode)
 	if err := e.encode(&MessageResponse{Message: message}); err != nil {
 		return err
@@ -103,13 +103,13 @@ func (e *Encoder) Forbidden(err error) error {
 }
 
 // ForbiddenWithMessage returns a forbidden response with an error message
-func (e *Encoder) ForbiddenWithMessage(message string, err error) error {
-	return e.statusCodeWithMessage(http.StatusForbidden, message, err)
+func (e *Encoder) ForbiddenWithMessage(err error, message string) error {
+	return e.statusCodeWithMessage(http.StatusForbidden, err, message)
 }
 
 // UnauthorizedWithMessage returns an unauthorized response with an error message
-func (e *Encoder) UnauthorizedWithMessage(message string, err error) error {
-	return e.statusCodeWithMessage(http.StatusUnauthorized, message, err)
+func (e *Encoder) UnauthorizedWithMessage(err error, message string) error {
+	return e.statusCodeWithMessage(http.StatusUnauthorized, err, message)
 }
 
 // BadRequest writes a http 400 status to the response header and returns the original error
@@ -118,8 +118,8 @@ func (e *Encoder) BadRequest(err error) error {
 }
 
 // BadRequestWithMessage writes a bad request with a message body in the response
-func (e *Encoder) BadRequestWithMessage(message string, err error) error {
-	return e.statusCodeWithMessage(http.StatusBadRequest, message, err)
+func (e *Encoder) BadRequestWithMessage(err error, message string) error {
+	return e.statusCodeWithMessage(http.StatusBadRequest, err, message)
 }
 
 // InternalServerError writes a 500 status to the response header and returns the original error
@@ -128,8 +128,8 @@ func (e *Encoder) InternalServerError(err error) error {
 }
 
 // InternalServerErrorWithMessage writes a 500 status to the response header and encodes a message in the response body
-func (e *Encoder) InternalServerErrorWithMessage(message string, err error) error {
-	return e.statusCodeWithMessage(http.StatusInternalServerError, message, err)
+func (e *Encoder) InternalServerErrorWithMessage(err error, message string) error {
+	return e.statusCodeWithMessage(http.StatusInternalServerError, err, message)
 }
 
 // NotFound writes a 404 status to the response header and returns the original error
@@ -138,8 +138,8 @@ func (e *Encoder) NotFound(err error) error {
 }
 
 // NotFoundWithMessage writes a 404 status to the response header and encodes a message in the response body
-func (e *Encoder) NotFoundWithMessage(message string, err error) error {
-	return e.statusCodeWithMessage(http.StatusNotFound, message, err)
+func (e *Encoder) NotFoundWithMessage(err error, message string) error {
+	return e.statusCodeWithMessage(http.StatusNotFound, err, message)
 }
 
 // Conflict writes a 409 status to the response header and returns the original error
@@ -148,8 +148,8 @@ func (e *Encoder) Conflict(err error) error {
 }
 
 // ConflictWithMessage writes a 409 status to the response header and encodes a message in the response body
-func (e *Encoder) ConflictWithMessage(message string, err error) error {
-	return e.statusCodeWithMessage(http.StatusConflict, message, err)
+func (e *Encoder) ConflictWithMessage(err error, message string) error {
+	return e.statusCodeWithMessage(http.StatusConflict, err, message)
 }
 
 // ServiceUnavailable writes a 503 status to the response header and returns the original error
@@ -158,6 +158,6 @@ func (e *Encoder) ServiceUnavailable(err error) error {
 }
 
 // ServiceUnavailableWithMessage writes a 503 status to the response header and encodes a message in the response body
-func (e *Encoder) ServiceUnavailableWithMessage(message string, err error) error {
-	return e.statusCodeWithMessage(http.StatusServiceUnavailable, message, err)
+func (e *Encoder) ServiceUnavailableWithMessage(err error, message string) error {
+	return e.statusCodeWithMessage(http.StatusServiceUnavailable, err, message)
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -214,7 +214,7 @@ func TestEncoder_StatusCodeWithMessage(t *testing.T) {
 			},
 			wantErr: true,
 			statusWithMessageFunc: func(e *Encoder, msg string, err error) error {
-				return e.UnauthorizedWithMessage(msg, err)
+				return e.UnauthorizedWithMessage(err, msg)
 			},
 			wantStatus: http.StatusUnauthorized,
 		},
@@ -226,7 +226,7 @@ func TestEncoder_StatusCodeWithMessage(t *testing.T) {
 			},
 			wantErr: true,
 			statusWithMessageFunc: func(e *Encoder, msg string, err error) error {
-				return e.InternalServerErrorWithMessage(msg, err)
+				return e.InternalServerErrorWithMessage(err, msg)
 			},
 			wantStatus: http.StatusInternalServerError,
 		},
@@ -238,7 +238,7 @@ func TestEncoder_StatusCodeWithMessage(t *testing.T) {
 			},
 			wantErr: true,
 			statusWithMessageFunc: func(e *Encoder, msg string, err error) error {
-				return e.BadRequestWithMessage(msg, err)
+				return e.BadRequestWithMessage(err, msg)
 			},
 			wantStatus: http.StatusBadRequest,
 		},
@@ -250,7 +250,7 @@ func TestEncoder_StatusCodeWithMessage(t *testing.T) {
 			},
 			wantErr: true,
 			statusWithMessageFunc: func(e *Encoder, msg string, err error) error {
-				return e.NotFoundWithMessage(msg, err)
+				return e.NotFoundWithMessage(err, msg)
 			},
 			wantStatus: http.StatusNotFound,
 		},
@@ -262,7 +262,7 @@ func TestEncoder_StatusCodeWithMessage(t *testing.T) {
 			},
 			wantErr: true,
 			statusWithMessageFunc: func(e *Encoder, msg string, err error) error {
-				return e.ConflictWithMessage(msg, err)
+				return e.ConflictWithMessage(err, msg)
 			},
 			wantStatus: http.StatusConflict,
 		},
@@ -274,7 +274,7 @@ func TestEncoder_StatusCodeWithMessage(t *testing.T) {
 			},
 			wantErr: true,
 			statusWithMessageFunc: func(e *Encoder, msg string, err error) error {
-				return e.ServiceUnavailableWithMessage(msg, err)
+				return e.ServiceUnavailableWithMessage(err, msg)
 			},
 			wantStatus: http.StatusServiceUnavailable,
 		},
@@ -286,7 +286,7 @@ func TestEncoder_StatusCodeWithMessage(t *testing.T) {
 			},
 			wantErr: true,
 			statusWithMessageFunc: func(e *Encoder, msg string, err error) error {
-				return e.StatusCodeWithMessage(202, msg, err)
+				return e.StatusCodeWithMessage(202, err, msg)
 			},
 			wantStatus: 202,
 		},

--- a/params.go
+++ b/params.go
@@ -29,7 +29,7 @@ func WithParams(next http.Handler) http.Handler {
 		defer func() {
 			if r := recover(); r != nil {
 				if m, ok := r.(paramErrMsg); ok {
-					_ = NewEncoder(w).BadRequestWithMessage(m.Msg(), errors.New(m.Msg()))
+					_ = NewEncoder(w).BadRequestWithMessage(errors.New(m.Msg()), m.Msg())
 				} else {
 					panic(r)
 				}


### PR DESCRIPTION
Every time I use the `...WithMessage()` methods in the `httpio` package, it stands out that the parameters are in reverse order of other packages that use a simular `...WithMessage()` API. The main example we are actively using is the `errors` package from `github.com/go-playground`.  `pkg/errors` is another example.

I am proposing that we make this breaking change so this package has the same feel as others that we use.