### PR TITLE
feature: Add support for encoding.TextUnmarshaler interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize, reopened] # these are the defaults - synchronize means 'commits pushed to PR'
 
 env:
-  GO_VERSION: "1.20.5"
+  GO_VERSION: "1.21.4"
 
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get dependencies
         shell: bash
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.52
+          version: v1.54
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,17 @@
 run:
   timeout: 3m
 linters-settings:
+  depguard:
+    rules:
+      main:
+        files:
+          - $all
+        allow:
+          - github.com/go-chi/chi/v5
+          - github.com/go-playground/errors/v5
+          - github.com/gofrs/uuid
+          - github.com/golang/mock/gomock
+          - $gostd
   dupl:
     threshold: 100
   funlen:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ func MyHandler(w http.ResponseWriter, r *http.Request) {
 
 The Params() generic function serves as an enhancement to the chi router's parameters feature by decoding HTTP URL parameters into native Go types.
 
-Currently the supported types are `string`, `int`, `int64`, `float64`, `bool`
+Currently the supported types are `string`, `int`, `int64`, `float64`, `bool`, and any type that implements the `encoding.TextUnmarshaler` interface.
 
 ### Example usage
 

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/go-chi/chi/v5 v5.0.10
-	github.com/go-playground/errors/v5 v5.3.0
+	github.com/go-playground/errors/v5 v5.4.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang/mock v1.6.0
 )
 
-require github.com/go-playground/pkg/v5 v5.21.2 // indirect
+require github.com/go-playground/pkg/v5 v5.21.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cccteam/httpio
 
-go 1.20
+go 1.21.4
 
 require (
 	github.com/go-chi/chi/v5 v5.0.10

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
 github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
-github.com/go-playground/errors/v5 v5.3.0 h1:Okot0WmH9v4bLz7wHad/gu1XrmqIHW6r5P4ubLv7QhE=
-github.com/go-playground/errors/v5 v5.3.0/go.mod h1:LcLhmzQ/RuEntAs9r38NSV+xtbHffhMx/1yuuEroc7M=
-github.com/go-playground/pkg/v5 v5.21.2 h1:DgVr88oMI3pfMFkEN9E6hp9YGG8NHc+019LRJfnUOfU=
-github.com/go-playground/pkg/v5 v5.21.2/go.mod h1:UgHNntEQnMJSygw2O2RQ3LAB0tprx81K90c/pOKh7cU=
+github.com/go-playground/errors/v5 v5.4.0 h1:BxBxwlRjuclYbRebE4ddrRrMK705lS2mHzHw7BDoDPA=
+github.com/go-playground/errors/v5 v5.4.0/go.mod h1:6aVeVHsT36RNu/m/8AvGdPv8T2J/+KfVv6Su4VvBfpQ=
+github.com/go-playground/pkg/v5 v5.21.3 h1:1IVy0eupI5kht6L6zaAqTEvjs00zLkG28ictNkoN1wE=
+github.com/go-playground/pkg/v5 v5.21.3/go.mod h1:UgHNntEQnMJSygw2O2RQ3LAB0tprx81K90c/pOKh7cU=
 github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
 github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,7 @@
-github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
-github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
 github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-playground/errors/v5 v5.3.0 h1:Okot0WmH9v4bLz7wHad/gu1XrmqIHW6r5P4ubLv7QhE=
 github.com/go-playground/errors/v5 v5.3.0/go.mod h1:LcLhmzQ/RuEntAs9r38NSV+xtbHffhMx/1yuuEroc7M=
-github.com/go-playground/pkg/v5 v5.15.2 h1:/PSAD9FTPd+pZ6dn22tCiKJGGCEbZMRXqkC/5bwvVBw=
-github.com/go-playground/pkg/v5 v5.15.2/go.mod h1:eT8XZeFHnqZkfkpkbI8ayjfCw9GohV2/j8STbVmoR6s=
 github.com/go-playground/pkg/v5 v5.21.2 h1:DgVr88oMI3pfMFkEN9E6hp9YGG8NHc+019LRJfnUOfU=
 github.com/go-playground/pkg/v5 v5.21.2/go.mod h1:UgHNntEQnMJSygw2O2RQ3LAB0tprx81K90c/pOKh7cU=
 github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=

--- a/params_test.go
+++ b/params_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/gofrs/uuid"
@@ -58,7 +57,7 @@ func TestWithParams(t *testing.T) {
 			defer func() {
 				r := recover()
 				if tt.wantPanic != (r != nil) {
-					t.Errorf("param() panic = %v, want %v", r != nil, tt.wantPanic)
+					t.Errorf("param() panic = %v, wantPanic %v", r, tt.wantPanic)
 				}
 			}()
 
@@ -112,7 +111,7 @@ func Test_param_string(t *testing.T) {
 			defer func() {
 				r := recover()
 				if tt.wantPanic != (r != nil) {
-					t.Errorf("param() panic = %v, want %v", r != nil, tt.wantPanic)
+					t.Errorf("param() panic = %v, wantPanic %v", r, tt.wantPanic)
 				}
 			}()
 
@@ -161,7 +160,7 @@ func Test_param_int(t *testing.T) {
 			defer func() {
 				r := recover()
 				if tt.wantPanic != (r != nil) {
-					t.Errorf("param() panic = %v, want %v", r != nil, tt.wantPanic)
+					t.Errorf("param() panic = %v, wantPanic %v", r, tt.wantPanic)
 				}
 			}()
 
@@ -210,7 +209,7 @@ func Test_param_int64(t *testing.T) {
 			defer func() {
 				r := recover()
 				if tt.wantPanic != (r != nil) {
-					t.Errorf("param() panic = %v, want %v", r != nil, tt.wantPanic)
+					t.Errorf("param() panic = %v, wantPanic %v", r, tt.wantPanic)
 				}
 			}()
 
@@ -259,7 +258,7 @@ func Test_param_float64(t *testing.T) {
 			defer func() {
 				r := recover()
 				if tt.wantPanic != (r != nil) {
-					t.Errorf("param() panic = %v, want %v", r != nil, tt.wantPanic)
+					t.Errorf("param() panic = %v, wantPanic %v", r, tt.wantPanic)
 				}
 			}()
 
@@ -348,7 +347,7 @@ func Test_param_bool(t *testing.T) {
 			defer func() {
 				r := recover()
 				if tt.wantPanic != (r != nil) {
-					t.Errorf("param() panic = %v, want %v", r != nil, tt.wantPanic)
+					t.Errorf("param() panic = %v, wantPanic %v", r, tt.wantPanic)
 				}
 			}()
 
@@ -397,11 +396,60 @@ func Test_param_UUID(t *testing.T) {
 			defer func() {
 				r := recover()
 				if tt.wantPanic != (r != nil) {
-					t.Errorf("param() panic = %v, want %v", r != nil, tt.wantPanic)
+					t.Errorf("param() panic = %v, wantPanic %v", r, tt.wantPanic)
 				}
 			}()
 
 			if gotVal := Param[uuid.UUID](tt.args.r, tt.args.param); gotVal != tt.wantVal {
+				t.Errorf("param() = %v, want %v", gotVal, tt.wantVal)
+			}
+		})
+	}
+}
+
+func Test_param_ptr_UUID(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		r     *http.Request
+		param ParamType
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantVal   uuid.UUID
+		wantPanic bool
+	}{
+		{
+			name: "Valid Param",
+			args: args{
+				r:     mockRequest(map[ParamType]string{"fileId": "0020198f-a14e-42ee-b5f8-65a228ba38e7"}),
+				param: ParamType("fileId"),
+			},
+			wantVal: uuid.FromStringOrNil("0020198f-a14e-42ee-b5f8-65a228ba38e7"),
+		},
+		{
+			name: "Invalid Param Panic",
+			args: args{
+				r:     mockRequest(map[ParamType]string{"fileId": "0020198f-a14e-42ee-b5f8-65a228ba38xx"}),
+				param: ParamType("fileId"),
+			},
+			wantPanic: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			defer func() {
+				r := recover()
+				if tt.wantPanic != (r != nil) {
+					t.Errorf("param() panic = %v, wantPanic %v", r, tt.wantPanic)
+				}
+			}()
+
+			if gotVal := Param[*uuid.UUID](tt.args.r, tt.args.param); *gotVal != tt.wantVal {
 				t.Errorf("param() = %v, want %v", gotVal, tt.wantVal)
 			}
 		})
@@ -418,7 +466,7 @@ func Test_param_notimplemented(t *testing.T) {
 	tests := []struct {
 		name      string
 		args      args
-		wantVal   time.Time
+		wantVal   struct{}
 		wantPanic bool
 	}{
 		{
@@ -438,11 +486,11 @@ func Test_param_notimplemented(t *testing.T) {
 			defer func() {
 				r := recover()
 				if tt.wantPanic != (r != nil) {
-					t.Errorf("param() panic = %v, want %v", r != nil, tt.wantPanic)
+					t.Errorf("param() panic = %v, wantPanic %v", r, tt.wantPanic)
 				}
 			}()
 
-			if gotVal := Param[time.Time](tt.args.r, tt.args.param); gotVal != tt.wantVal {
+			if gotVal := Param[struct{}](tt.args.r, tt.args.param); gotVal != tt.wantVal {
 				t.Errorf("param() = %v, want %v", gotVal, tt.wantVal)
 			}
 		})


### PR DESCRIPTION
This implements the `encoding.TextUnmarshaler` interface to allow support of custom types. I removed direct support for `uuid.UUID` since it implements this interface. The test shows that `uuid.UUID` continues to be supported.